### PR TITLE
fix: fix cjs -> esm breakchange, to #82

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,22 @@
       "url": "https://technote.space"
     }
   ],
+  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
   "type": "module",
-  "exports": "./dist/index.mjs",
-  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": [
+      {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs"
+      },
+      "./dist/index.cjs"
+    ]
+  },
   "files": [
-    "build"
+    "dist"
   ],
   "scripts": {
     "build": "tsc --emitDeclarationOnly && rollup -c",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@sindresorhus/tsconfig",
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es2020",
+    "target": "es6",
     "lib": [
       "es2020"
     ],


### PR DESCRIPTION
version 2.5.0 cjs -> esm must be a breakchange

If you want to be compatible with lower versions of nodejs, you can merge this pull request, otherwise restore 2.x to cjs, change to esm  in 3.x