### PR TITLE
release: v2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,22 @@
       "url": "https://technote.space"
     }
   ],
+  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
   "type": "module",
-  "exports": "./dist/index.mjs",
-  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": [
+      {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs"
+      },
+      "./dist/index.cjs"
+    ]
+  },
   "files": [
-    "build"
+    "dist"
   ],
   "scripts": {
     "build": "tsc --emitDeclarationOnly && rollup -c",

--- a/package.json
+++ b/package.json
@@ -46,16 +46,16 @@
   },
   "dependencies": {
     "@technote-space/anchor-markdown-header": "^1.1.36",
-    "@textlint/markdown-to-ast": "^12.1.1",
+    "@textlint/markdown-to-ast": "^12.2.1",
     "htmlparser2": "^8.0.1",
     "update-section": "^0.3.3"
   },
   "devDependencies": {
-    "@commitlint/cli": "^17.0.2",
-    "@commitlint/config-conventional": "^17.0.2",
+    "@commitlint/cli": "^17.0.3",
+    "@commitlint/config-conventional": "^17.0.3",
     "@rollup/plugin-typescript": "^8.3.3",
     "@sindresorhus/tsconfig": "^3.0.1",
-    "@textlint/ast-node-types": "^12.1.1",
+    "@textlint/ast-node-types": "^12.2.1",
     "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
@@ -63,10 +63,10 @@
     "eslint": "^8.18.0",
     "eslint-plugin-import": "^2.26.0",
     "husky": "^8.0.1",
-    "lint-staged": "^13.0.2",
+    "lint-staged": "^13.0.3",
     "rollup": "^2.75.7",
     "typescript": "^4.7.4",
-    "vitest": "^0.15.2"
+    "vitest": "^0.16.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -29,20 +29,13 @@
       "url": "https://technote.space"
     }
   ],
-  "types": "dist/index.d.ts",
-  "main": "dist/index.cjs",
   "type": "module",
-  "module": "dist/index.mjs",
   "exports": {
-    ".": [
-      {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.cjs"
-      },
-      "./dist/index.cjs"
-    ]
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.cjs"
   },
+  "main": "dist/index.mjs",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/doctoc",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Generates TOC for markdown files of local git repo.",
   "keywords": [
     "github",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,8 @@ const common = {
     '@textlint/markdown-to-ast',
     'htmlparser2',
     'update-section',
+    'fs',
+    'path',
   ],
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@sindresorhus/tsconfig",
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es6",
+    "target": "es2020",
     "lib": [
       "es2020"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@sindresorhus/tsconfig",
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es2020",
+    "target": "es6",
     "lib": [
       "es2020"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,14 +28,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@commitlint/cli@^17.0.2":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-17.0.2.tgz#57c925fb5f09b8e4a83448d94db291ddf7aa58ee"
-  integrity sha512-Axe89Js0YzGGd4gxo3JLlF7yIdjOVpG1LbOorGc6PfYF+drBh14PvarSDLzyd2TNqdylUCq9wb9/A88ZjIdyhA==
+"@commitlint/cli@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-17.0.3.tgz#50be9d9a8d79f6c47bfd2703638fe65215eb2526"
+  integrity sha512-oAo2vi5d8QZnAbtU5+0cR2j+A7PO8zuccux65R/EycwvsZrDVyW518FFrnJK2UQxbRtHFFIG+NjQ6vOiJV0Q8A==
   dependencies:
     "@commitlint/format" "^17.0.0"
-    "@commitlint/lint" "^17.0.0"
-    "@commitlint/load" "^17.0.0"
+    "@commitlint/lint" "^17.0.3"
+    "@commitlint/load" "^17.0.3"
     "@commitlint/read" "^17.0.0"
     "@commitlint/types" "^17.0.0"
     execa "^5.0.0"
@@ -44,20 +44,20 @@
     resolve-global "1.0.0"
     yargs "^17.0.0"
 
-"@commitlint/config-conventional@^17.0.2":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-17.0.2.tgz#298c9076e25c1e8760f04ee1be8ce43c856a4b72"
-  integrity sha512-MfP0I/JbxKkzo+HXWB7B3WstGS4BiniotU3d3xQ9gK8cR0DbeZ4MuyGCWF65YDyrcDTS3WlrJ3ndSPA1pqhoPw==
+"@commitlint/config-conventional@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-17.0.3.tgz#61e937357ce63ea08a2017e58b918748fcf3abc5"
+  integrity sha512-HCnzTm5ATwwwzNVq5Y57poS0a1oOOcd5pc1MmBpLbGmSysc4i7F/++JuwtdFPu16sgM3H9J/j2zznRLOSGVO2A==
   dependencies:
     conventional-changelog-conventionalcommits "^5.0.0"
 
-"@commitlint/config-validator@^17.0.0":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-validator/-/config-validator-17.0.0.tgz#49ab09f3ca0ac3449e79ea389cb4942423162ac0"
-  integrity sha512-78IQjoZWR4kDHp/U5y17euEWzswJpPkA9TDL5F6oZZZaLIEreWzrDZD5PWtM8MsSRl/K2LDU/UrzYju2bKLMpA==
+"@commitlint/config-validator@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-validator/-/config-validator-17.0.3.tgz#5d1ec17eece1f85a0d06c05d168a039b313eb5d7"
+  integrity sha512-3tLRPQJKapksGE7Kee9axv+9z5I2GDHitDH4q63q7NmNA0wkB+DAorJ0RHz2/K00Zb1/MVdHzhCga34FJvDihQ==
   dependencies:
     "@commitlint/types" "^17.0.0"
-    ajv "^6.12.6"
+    ajv "^8.11.0"
 
 "@commitlint/ensure@^17.0.0":
   version "17.0.0"
@@ -80,32 +80,32 @@
     "@commitlint/types" "^17.0.0"
     chalk "^4.1.0"
 
-"@commitlint/is-ignored@^17.0.0":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-17.0.0.tgz#64f53517b390689e58aa3c29fbf1e05b7d4fbd65"
-  integrity sha512-UmacD0XM/wWykgdXn5CEWVS4XGuqzU+ZGvM2hwv85+SXGnIOaG88XHrt81u37ZeVt1riWW+YdOxcJW6+nd5v5w==
+"@commitlint/is-ignored@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@commitlint/is-ignored/-/is-ignored-17.0.3.tgz#0e1c725c1e50aea5852fb1260bc92b2ee1856425"
+  integrity sha512-/wgCXAvPtFTQZxsVxj7owLeRf5wwzcXLaYmrZPR4a87iD4sCvUIRl1/ogYrtOyUmHwWfQsvjqIB4mWE/SqWSnA==
   dependencies:
     "@commitlint/types" "^17.0.0"
     semver "7.3.7"
 
-"@commitlint/lint@^17.0.0":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-17.0.0.tgz#38ef61e0e977d738f738233fbcdf33a5fc04cf96"
-  integrity sha512-5FL7VLvGJQby24q0pd4UdM8FNFcL+ER1T/UBf8A9KRL5+QXV1Rkl6Zhcl7+SGpGlVo6Yo0pm6aLW716LVKWLGg==
+"@commitlint/lint@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@commitlint/lint/-/lint-17.0.3.tgz#98542a48f03b5c144309e24cbe1c032366ea75e2"
+  integrity sha512-2o1fk7JUdxBUgszyt41sHC/8Nd5PXNpkmuOo9jvGIjDHzOwXyV0PSdbEVTH3xGz9NEmjohFHr5l+N+T9fcxong==
   dependencies:
-    "@commitlint/is-ignored" "^17.0.0"
+    "@commitlint/is-ignored" "^17.0.3"
     "@commitlint/parse" "^17.0.0"
     "@commitlint/rules" "^17.0.0"
     "@commitlint/types" "^17.0.0"
 
-"@commitlint/load@^17.0.0":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-17.0.0.tgz#0bbefe6d8b99276714c5ea8ef32de2bd2f082698"
-  integrity sha512-XaiHF4yWQOPAI0O6wXvk+NYLtJn/Xb7jgZEeKd4C1ZWd7vR7u8z5h0PkWxSr0uLZGQsElGxv3fiZ32C5+q6M8w==
+"@commitlint/load@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-17.0.3.tgz#683aa484a5515714512e442f2f4b11f75e66097a"
+  integrity sha512-3Dhvr7GcKbKa/ey4QJ5MZH3+J7QFlARohUow6hftQyNjzoXXROm+RwpBes4dDFrXG1xDw9QPXA7uzrOShCd4bw==
   dependencies:
-    "@commitlint/config-validator" "^17.0.0"
+    "@commitlint/config-validator" "^17.0.3"
     "@commitlint/execute-rule" "^17.0.0"
-    "@commitlint/resolve-extends" "^17.0.0"
+    "@commitlint/resolve-extends" "^17.0.3"
     "@commitlint/types" "^17.0.0"
     "@types/node" ">=12"
     chalk "^4.1.0"
@@ -139,12 +139,12 @@
     fs-extra "^10.0.0"
     git-raw-commits "^2.0.0"
 
-"@commitlint/resolve-extends@^17.0.0":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-17.0.0.tgz#3a40ee08184b984acf475ebc962641f435e3a639"
-  integrity sha512-wi60WiJmwaQ7lzMXK8Vbc18Hq9tE2j/6iv2AFfPUGV7fvfY6Sf1iNKuUHirSqR0fquUyufIXe4y/K9A6LVIIvw==
+"@commitlint/resolve-extends@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-17.0.3.tgz#43b237899e2abd59d16af091521b888c8a071412"
+  integrity sha512-H/RFMvrcBeJCMdnVC4i8I94108UDccIHrTke2tyQEg9nXQnR5/Hd6MhyNWkREvcrxh9Y+33JLb+PiPiaBxCtBA==
   dependencies:
-    "@commitlint/config-validator" "^17.0.0"
+    "@commitlint/config-validator" "^17.0.3"
     "@commitlint/types" "^17.0.0"
     import-fresh "^3.0.0"
     lodash "^4.17.19"
@@ -240,7 +240,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.7":
+"@jridgewell/trace-mapping@^0.3.12":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz#dcfe3e95f224c8fe97a87a5235defec999aa92ea"
   integrity sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
@@ -298,18 +298,18 @@
   dependencies:
     emoji-regex "^10.0.1"
 
-"@textlint/ast-node-types@^12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-12.1.1.tgz#189cdc932a50b9dd14b6829848408c22bb72f976"
-  integrity sha512-5/XK9S1177UYetOY6407o1RDuNVndaYfuzsZwhmo52V367s4ZuUD2064WhbmCd6TPyKD4dVr2zoWjfNDfzUZQg==
+"@textlint/ast-node-types@^12.2.1":
+  version "12.2.1"
+  resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-12.2.1.tgz#bec1e4b02e97ff1167d057c71feeee1a80015aef"
+  integrity sha512-NXYza6aG1+LdZ4g83gjRhDht+gdrTjJYkdcQhpvzNCtTar/sVpaykkauRcAKLhkIWrQpfb311pfMlU6qNDW76Q==
 
-"@textlint/markdown-to-ast@^12.1.1":
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/@textlint/markdown-to-ast/-/markdown-to-ast-12.1.1.tgz#08f67f48e5d9fba34dec4c5102df2674dc94afc2"
-  integrity sha512-TmqFyNqi68YpkqKabrkMlPzeSJMfY/+Wsv1/r43uDFgSYyM9GiD0eIpP12uKyL8xLW+rgfbqXxeFwSo26Conqw==
+"@textlint/markdown-to-ast@^12.2.1":
+  version "12.2.1"
+  resolved "https://registry.yarnpkg.com/@textlint/markdown-to-ast/-/markdown-to-ast-12.2.1.tgz#e9ec19be71e4513d882986d14ab9a993dec74511"
+  integrity sha512-p+LlVcrgHnSNEWWflYU412uu+v4Cejs6hmI4SgZCheNg4u7Ik78aKgpe4jT5BhjLSBZ/KP6IrJxtCUOoJIUWmQ==
   dependencies:
-    "@textlint/ast-node-types" "^12.1.1"
-    debug "^4.3.3"
+    "@textlint/ast-node-types" "^12.2.1"
+    debug "^4.3.4"
     remark-footnotes "^3.0.0"
     remark-frontmatter "^3.0.0"
     remark-gfm "^1.0.0"
@@ -512,7 +512,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.6:
+ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -520,6 +520,16 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.6:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-escapes@^4.3.0:
@@ -860,12 +870,12 @@ convert-source-map@^1.6.0:
     safe-buffer "~5.1.1"
 
 cosmiconfig-typescript-loader@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-2.0.1.tgz#5622bb1eb87d293570bcc3a57f406940e0960113"
-  integrity sha512-B9s6sX/omXq7I6gC6+YgLmrBFMJhPWew7ty/X5Tuwtd2zOSgWaUdXjkuVwbe3qqcdETo60+1nSVMekq//LIXVA==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-2.0.2.tgz#7e7ce6064af041c910e1e43fb0fd9625cee56e93"
+  integrity sha512-KmE+bMjWMXJbkWCeY4FJX/npHuZPNr9XF9q9CIQ/bpFwi1qHfCmSiKarrCcRa0LO4fWjk93pVoeRtJAkTGcYNw==
   dependencies:
     cosmiconfig "^7"
-    ts-node "^10.8.0"
+    ts-node "^10.8.1"
 
 cosmiconfig@^7, cosmiconfig@^7.0.0:
   version "7.0.1"
@@ -911,7 +921,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@^4.0.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2027,6 +2037,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -2076,10 +2091,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-lint-staged@^13.0.2:
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.0.2.tgz#35a1c57130e9ad5b1dea784972a40777ba433dd5"
-  integrity sha512-qQLfLTh9z34eMzfEHENC+QBskZfxjomrf+snF3xJ4BzilORbD989NLqQ00ughsF/A+PT41e87+WsMFabf9++pQ==
+lint-staged@^13.0.3:
+  version "13.0.3"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.0.3.tgz#d7cdf03a3830b327a2b63c6aec953d71d9dc48c6"
+  integrity sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==
   dependencies:
     cli-truncate "^3.1.0"
     colorette "^2.0.17"
@@ -2830,6 +2845,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 resolve-from@5.0.0, resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
@@ -3163,10 +3183,10 @@ through2@^4.0.0:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tinypool@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.1.3.tgz#b5570b364a1775fd403de5e7660b325308fee26b"
-  integrity sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==
+tinypool@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.2.1.tgz#7c3347514de36113f224212590de17f04fdf0078"
+  integrity sha512-HFU5ZYVq3wBfhSaf8qdqGsneaqXm0FgJQpoUlJbVdHpRLzm77IneKAD3RjzJWZvIv0YpPB9S7LUW53f6BE6ZSg==
 
 tinyspy@^0.3.3:
   version "0.3.3"
@@ -3195,7 +3215,7 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-ts-node@^10.8.0:
+ts-node@^10.8.1:
   version "10.8.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.1.tgz#ea2bd3459011b52699d7e88daa55a45a1af4f066"
   integrity sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==
@@ -3358,11 +3378,11 @@ v8-compile-cache@^2.0.3:
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 v8-to-istanbul@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.0.0.tgz#be0dae58719fc53cb97e5c7ac1d7e6d4f5b19511"
-  integrity sha512-HcvgY/xaRm7isYmyx+lFKA4uQmfUbN0J4M0nNItvzTvH/iQ9kW5j/t4YSR+Ge323/lrgDAWJoF46tzGQHwBHFw==
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz#b6f994b0b5d4ef255e17a0d17dc444a9f5132fa4"
+  integrity sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.7"
+    "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
 
@@ -3404,10 +3424,10 @@ vite@^2.9.12:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@^0.15.2:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.15.2.tgz#3931c390685ff03331298c7719d27d691f79e782"
-  integrity sha512-cMabuUqu+nNHafkdN7H8Z20+UZTrrUfqjGwAoLwUwrqFGWBz3gXwxndjbLf6mgSFs9lF/JWjKeNM1CXKwtk26w==
+vitest@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.16.0.tgz#6858a864b25850d28252bc480b0c89014ff48ce8"
+  integrity sha512-Ntp6jrM8wf2NMtamMBLkRBBdeqHkgAH/WMh5Xryts1j2ft2D8QZQbiSVFkSl4WmEQzcPP0YM069g/Ga1vtnEtg==
   dependencies:
     "@types/chai" "^4.3.1"
     "@types/chai-subset" "^1.3.3"
@@ -3415,7 +3435,7 @@ vitest@^0.15.2:
     chai "^4.3.6"
     debug "^4.3.4"
     local-pkg "^0.4.1"
-    tinypool "^0.1.3"
+    tinypool "^0.2.1"
     tinyspy "^0.3.3"
     vite "^2.9.12"
 


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes

- [ ] fix: fix cjs -> esm breakchange, to closes #82 (#83) @malei0311
* fix: compatible with nodejs version that only support cjs (685574c4cda2c3f7a0b5fb5bf91c2841eb3c5fae)
* fix: compatible with nodejs version that not supports exnext syntax, e.g. ?? (Optional chaining operator) (596e89ff90d487b632d055cb10750bfa72432a1e)
* fix: unresolved dependencies (94a4f0bea75a559b6bcc3c9d4c2c3febcff3e9cb)
* chore: update npm dependencies (d1d6fad0a5f6be19e01eebe14c2cf7c6063f83b0)
* chore: tweaks (3d4512f52029d98170105d54367abd77c14a93c8)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/doctoc/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/doctoc/doctoc/package.json

 @textlint/markdown-to-ast        ^12.1.1  →  ^12.2.1     
 @commitlint/cli                  ^17.0.2  →  ^17.0.3     
 @commitlint/config-conventional  ^17.0.2  →  ^17.0.3     
 @textlint/ast-node-types         ^12.1.1  →  ^12.2.1     
 lint-staged                      ^13.0.2  →  ^13.0.3     
 vitest                           ^0.15.2  →  ^0.16.0     

Run yarn install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 14.97s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 331 new dependencies.
info Direct dependencies
├─ @commitlint/cli@17.0.3
├─ @commitlint/config-conventional@17.0.3
├─ @rollup/plugin-typescript@8.3.3
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/anchor-markdown-header@1.1.36
├─ @textlint/markdown-to-ast@12.2.1
├─ @types/node@18.0.0
├─ @typescript-eslint/eslint-plugin@5.29.0
├─ @typescript-eslint/parser@5.29.0
├─ c8@7.11.3
├─ eslint-plugin-import@2.26.0
├─ eslint@8.18.0
├─ htmlparser2@8.0.1
├─ husky@8.0.1
├─ lint-staged@13.0.3
├─ rollup@2.75.7
├─ typescript@4.7.4
├─ update-section@0.3.3
└─ vitest@0.16.0
info All dependencies
├─ @babel/code-frame@7.16.7
├─ @babel/helper-validator-identifier@7.16.7
├─ @babel/highlight@7.17.12
├─ @bcoe/v8-coverage@0.2.3
├─ @commitlint/cli@17.0.3
├─ @commitlint/config-conventional@17.0.3
├─ @commitlint/ensure@17.0.0
├─ @commitlint/execute-rule@17.0.0
├─ @commitlint/format@17.0.0
├─ @commitlint/is-ignored@17.0.3
├─ @commitlint/lint@17.0.3
├─ @commitlint/load@17.0.3
├─ @commitlint/message@17.0.0
├─ @commitlint/parse@17.0.0
├─ @commitlint/read@17.0.0
├─ @commitlint/resolve-extends@17.0.3
├─ @commitlint/rules@17.0.0
├─ @commitlint/to-lines@17.0.0
├─ @commitlint/top-level@17.0.0
├─ @cspotcode/source-map-support@0.8.1
├─ @eslint/eslintrc@1.3.0
├─ @humanwhocodes/config-array@0.9.5
├─ @humanwhocodes/object-schema@1.2.1
├─ @istanbuljs/schema@0.1.3
├─ @jridgewell/trace-mapping@0.3.13
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.8
├─ @rollup/plugin-typescript@8.3.3
├─ @rollup/pluginutils@3.1.0
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/anchor-markdown-header@1.1.36
├─ @textlint/markdown-to-ast@12.2.1
├─ @tsconfig/node10@1.0.9
├─ @tsconfig/node12@1.0.11
├─ @tsconfig/node14@1.0.3
├─ @tsconfig/node16@1.0.3
├─ @types/chai-subset@1.3.3
├─ @types/chai@4.3.1
├─ @types/estree@0.0.39
├─ @types/istanbul-lib-coverage@2.0.4
├─ @types/json-schema@7.0.11
├─ @types/json5@0.0.29
├─ @types/mdast@3.0.10
├─ @types/minimist@1.2.2
├─ @types/node@18.0.0
├─ @types/normalize-package-data@2.4.1
├─ @types/parse-json@4.0.0
├─ @typescript-eslint/eslint-plugin@5.29.0
├─ @typescript-eslint/parser@5.29.0
├─ @typescript-eslint/type-utils@5.29.0
├─ acorn-jsx@5.3.2
├─ acorn-walk@8.2.0
├─ acorn@8.7.1
├─ aggregate-error@3.1.0
├─ ajv@6.12.6
├─ ansi-escapes@4.3.2
├─ ansi-regex@5.0.1
├─ arg@4.1.3
├─ argparse@2.0.1
├─ array-ify@1.0.0
├─ array-includes@3.1.5
├─ array-union@2.1.0
├─ array.prototype.flat@1.3.0
├─ arrify@1.0.1
├─ assertion-error@1.1.0
├─ bail@1.0.5
├─ balanced-match@1.0.2
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ c8@7.11.3
├─ callsites@3.1.0
├─ camelcase-keys@6.2.2
├─ camelcase@5.3.1
├─ ccount@1.1.0
├─ chai@4.3.6
├─ chalk@4.1.2
├─ character-entities-legacy@1.1.4
├─ character-entities@1.2.4
├─ character-reference-invalid@1.1.4
├─ check-error@1.0.2
├─ clean-stack@2.2.0
├─ cli-cursor@3.1.0
├─ cli-truncate@3.1.0
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ colorette@2.0.19
├─ commander@9.3.0
├─ concat-map@0.0.1
├─ conventional-changelog-angular@5.0.13
├─ conventional-changelog-conventionalcommits@5.0.0
├─ conventional-commits-parser@3.2.4
├─ convert-source-map@1.8.0
├─ cosmiconfig-typescript-loader@2.0.2
├─ cosmiconfig@7.0.1
├─ create-require@1.1.1
├─ dargs@7.0.0
├─ decamelize-keys@1.1.0
├─ decamelize@1.2.0
├─ deep-eql@3.0.1
├─ deep-is@0.1.4
├─ diff@4.0.2
├─ dir-glob@3.0.1
├─ doctrine@2.1.0
├─ dom-serializer@2.0.0
├─ domutils@3.0.1
├─ dot-prop@5.3.0
├─ eastasianwidth@0.2.0
├─ emoji-regex@10.1.0
├─ entities@4.3.0
├─ error-ex@1.3.2
├─ es-shim-unscopables@1.0.0
├─ es-to-primitive@1.2.1
├─ esbuild-linux-64@0.14.47
├─ esbuild@0.14.47
├─ eslint-import-resolver-node@0.3.6
├─ eslint-module-utils@2.7.3
├─ eslint-plugin-import@2.26.0
├─ eslint-scope@7.1.1
├─ eslint@8.18.0
├─ esquery@1.4.0
├─ estraverse@5.3.0
├─ estree-walker@1.0.1
├─ extend@3.0.2
├─ fast-glob@3.2.11
├─ fast-json-stable-stringify@2.1.0
├─ fast-levenshtein@2.0.6
├─ fastq@1.13.0
├─ fault@1.0.4
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ flat-cache@3.0.4
├─ flatted@3.2.5
├─ foreground-child@2.0.0
├─ format@0.2.2
├─ fs-extra@10.1.0
├─ fs.realpath@1.0.0
├─ function.prototype.name@1.1.5
├─ get-stream@6.0.1
├─ get-symbol-description@1.0.0
├─ git-raw-commits@2.0.11
├─ glob-parent@6.0.2
├─ glob@7.2.3
├─ global-dirs@0.1.1
├─ globby@11.1.0
├─ graceful-fs@4.2.10
├─ hard-rejection@2.1.0
├─ has-bigints@1.0.2
├─ has-flag@4.0.0
├─ hosted-git-info@4.1.0
├─ html-escaper@2.0.2
├─ htmlparser2@8.0.1
├─ human-signals@2.1.0
├─ husky@8.0.1
├─ imurmurhash@0.1.4
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ini@1.3.8
├─ internal-slot@1.0.3
├─ is-alphabetical@1.0.4
├─ is-alphanumerical@1.0.4
├─ is-arrayish@0.2.1
├─ is-bigint@1.0.4
├─ is-boolean-object@1.1.2
├─ is-callable@1.2.4
├─ is-core-module@2.9.0
├─ is-date-object@1.0.5
├─ is-extglob@2.1.1
├─ is-hexadecimal@1.0.4
├─ is-negative-zero@2.0.2
├─ is-number-object@1.0.7
├─ is-number@7.0.0
├─ is-obj@2.0.0
├─ is-plain-obj@2.1.0
├─ is-regex@1.1.4
├─ is-shared-array-buffer@1.0.2
├─ is-stream@2.0.1
├─ is-string@1.0.7
├─ is-symbol@1.0.4
├─ is-text-path@1.0.1
├─ is-weakref@1.0.2
├─ isexe@2.0.0
├─ istanbul-lib-coverage@3.2.0
├─ istanbul-reports@3.1.4
├─ js-tokens@4.0.0
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json5@1.0.1
├─ jsonfile@6.1.0
├─ jsonparse@1.3.1
├─ JSONStream@1.3.5
├─ kind-of@6.0.3
├─ lilconfig@2.0.5
├─ lines-and-columns@1.2.4
├─ lint-staged@13.0.3
├─ listr2@4.0.5
├─ local-pkg@0.4.1
├─ locate-path@6.0.0
├─ lodash.merge@4.6.2
├─ log-update@4.0.0
├─ longest-streak@2.0.4
├─ loupe@2.3.4
├─ make-dir@3.1.0
├─ make-error@1.3.6
├─ map-obj@1.0.1
├─ markdown-table@2.0.0
├─ mdast-util-find-and-replace@1.1.1
├─ mdast-util-footnote@0.1.7
├─ mdast-util-from-markdown@0.8.5
├─ mdast-util-frontmatter@0.2.0
├─ mdast-util-gfm-autolink-literal@0.1.3
├─ mdast-util-gfm-strikethrough@0.2.3
├─ mdast-util-gfm-table@0.1.6
├─ mdast-util-gfm-task-list-item@0.1.6
├─ mdast-util-gfm@0.1.2
├─ merge2@1.4.1
├─ micromark-extension-footnote@0.3.2
├─ micromark-extension-gfm-autolink-literal@0.5.7
├─ micromark-extension-gfm-strikethrough@0.6.5
├─ micromark-extension-gfm-table@0.4.3
├─ micromark-extension-gfm-tagfilter@0.3.0
├─ micromark-extension-gfm-task-list-item@0.3.3
├─ micromark-extension-gfm@0.3.3
├─ micromark@2.11.4
├─ micromatch@4.0.5
├─ mimic-fn@2.1.0
├─ min-indent@1.0.1
├─ minimist-options@4.1.0
├─ minimist@1.2.6
├─ ms@2.1.2
├─ nanoid@3.3.4
├─ natural-compare@1.4.0
├─ normalize-package-data@3.0.3
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ object-inspect@1.12.2
├─ object.assign@4.1.2
├─ object.values@1.1.5
├─ onetime@5.1.2
├─ optionator@0.9.1
├─ p-limit@3.1.0
├─ p-locate@5.0.0
├─ p-map@4.0.0
├─ p-try@1.0.0
├─ parent-module@1.0.1
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ pathval@1.1.1
├─ picocolors@1.0.0
├─ picomatch@2.3.1
├─ pidtree@0.6.0
├─ postcss@8.4.14
├─ punycode@2.1.1
├─ queue-microtask@1.2.3
├─ quick-lru@4.0.1
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ readable-stream@3.6.0
├─ redent@3.0.0
├─ regexp.prototype.flags@1.4.3
├─ remark-footnotes@3.0.0
├─ remark-frontmatter@3.0.0
├─ remark-gfm@1.0.0
├─ remark-parse@9.0.0
├─ require-from-string@2.0.2
├─ resolve-global@1.0.0
├─ restore-cursor@3.1.0
├─ reusify@1.0.4
├─ rfdc@1.3.0
├─ rollup@2.75.7
├─ run-parallel@1.2.0
├─ rxjs@7.5.5
├─ safe-buffer@5.1.2
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ side-channel@1.0.4
├─ slash@3.0.0
├─ slice-ansi@5.0.0
├─ source-map-js@1.0.2
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ string_decoder@1.3.0
├─ string-argv@0.3.1
├─ string.prototype.trimend@1.0.5
├─ string.prototype.trimstart@1.0.5
├─ strip-bom@3.0.0
├─ strip-final-newline@2.0.0
├─ strip-indent@3.0.0
├─ strip-json-comments@3.1.1
├─ supports-preserve-symlinks-flag@1.0.0
├─ test-exclude@6.0.0
├─ text-extensions@1.9.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ tinypool@0.2.1
├─ tinyspy@0.3.3
├─ to-regex-range@5.0.1
├─ traverse@0.6.6
├─ trim-newlines@3.0.1
├─ trough@1.0.5
├─ ts-node@10.8.1
├─ tsconfig-paths@3.14.1
├─ tslib@1.14.1
├─ type-check@0.4.0
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typescript@4.7.4
├─ unbox-primitive@1.0.2
├─ unified@9.2.2
├─ unist-util-visit-parents@3.1.1
├─ update-section@0.3.3
├─ util-deprecate@1.0.2
├─ v8-compile-cache-lib@3.0.1
├─ v8-compile-cache@2.3.0
├─ v8-to-istanbul@9.0.1
├─ vfile-message@2.0.4
├─ vfile@4.2.1
├─ vite@2.9.12
├─ vitest@0.16.0
├─ which-boxed-primitive@1.0.2
├─ which@2.0.2
├─ word-wrap@1.2.3
├─ yallist@4.0.0
├─ yaml@2.1.1
├─ yargs-parser@20.2.9
├─ yargs@16.2.0
├─ yn@3.1.1
├─ yocto-queue@0.1.0
└─ zwitch@1.0.5
Done in 7.42s.
```



</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.19
0 vulnerabilities found - Packages audited: 512
Done in 0.53s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)