### PR TITLE
release: v2.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "update": "npm_config_yes=true npx npm-check-updates -u --timeout 100000 && yarn install && yarn upgrade && yarn audit"
   },
   "dependencies": {
-    "@technote-space/anchor-markdown-header": "^1.1.39",
+    "@technote-space/anchor-markdown-header": "^1.1.40",
     "@textlint/markdown-to-ast": "^13.3.2",
     "htmlparser2": "^8.0.2",
     "update-section": "^0.3.3"
@@ -60,15 +60,15 @@
     "@rollup/plugin-typescript": "^11.1.0",
     "@sindresorhus/tsconfig": "^3.0.1",
     "@textlint/ast-node-types": "^13.3.2",
-    "@types/node": "^18.16.0",
-    "@typescript-eslint/eslint-plugin": "^5.59.0",
-    "@typescript-eslint/parser": "^5.59.0",
+    "@types/node": "^18.16.3",
+    "@typescript-eslint/eslint-plugin": "^5.59.1",
+    "@typescript-eslint/parser": "^5.59.1",
     "@vitest/coverage-c8": "^0.30.1",
     "eslint": "^8.39.0",
     "eslint-plugin-import": "^2.27.5",
     "husky": "^8.0.3",
-    "lint-staged": "^13.2.1",
-    "rollup": "^3.20.7",
+    "lint-staged": "^13.2.2",
+    "rollup": "^3.21.2",
     "typescript": "^5.0.4",
     "vitest": "^0.30.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/doctoc",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Generates TOC for markdown files of local git repo.",
   "keywords": [
     "github",

--- a/yarn.lock
+++ b/yarn.lock
@@ -314,9 +314,9 @@
     eslint-visitor-keys "^3.3.0"
 
 "@eslint-community/regexpp@^4.4.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.0.tgz#f6f729b02feee2c749f57e334b7a1b5f40a81724"
-  integrity sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
+  integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
 
 "@eslint/eslintrc@^2.0.2":
   version "2.0.2"
@@ -441,10 +441,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/tsconfig/-/tsconfig-3.0.1.tgz#e2eaebda42aa7a755b11bdfbea847446652e1ac4"
   integrity sha512-0/gtPNTY3++0J2BZM5nHHULg0BIMw886gqdn8vWN+Av6bgF5ZU2qIcHubAn+Z9KNvJhO8WFE+9kDOU3n6OcKtA==
 
-"@technote-space/anchor-markdown-header@^1.1.39":
-  version "1.1.39"
-  resolved "https://registry.yarnpkg.com/@technote-space/anchor-markdown-header/-/anchor-markdown-header-1.1.39.tgz#ae4216555f3347d1747c76cefa1c0ea0b43efaf4"
-  integrity sha512-DgaYUCqL39//LUbcwq5kVcImvL9+Nw2P44Ch7B45EpkQTx6ONrOuMxULpyBNHCCt+I+0bwSjsLJXKy+0WoErXA==
+"@technote-space/anchor-markdown-header@^1.1.40":
+  version "1.1.40"
+  resolved "https://registry.yarnpkg.com/@technote-space/anchor-markdown-header/-/anchor-markdown-header-1.1.40.tgz#2ed8b95e8c7133627f815249152dca3d523c7263"
+  integrity sha512-AtJAwNv/uFzpn9cRTeaUU2A8fd8nBdmNbcAHRlCS9sK8Glu0kkJRLd3BsrNFr86Cih3/9TwI9eGjPGkEmjfyHw==
   dependencies:
     emoji-regex "^10.2.1"
 
@@ -496,9 +496,9 @@
     "@types/chai" "*"
 
 "@types/chai@*", "@types/chai@^4.3.4":
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.4.tgz#e913e8175db8307d78b4e8fa690408ba6b65dee4"
-  integrity sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.5.tgz#ae69bcbb1bebb68c4ac0b11e9d8ed04526b3562b"
+  integrity sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==
 
 "@types/estree@^1.0.0":
   version "1.0.1"
@@ -532,10 +532,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*", "@types/node@^18.16.0":
-  version "18.16.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.0.tgz#4668bc392bb6938637b47e98b1f2ed5426f33316"
-  integrity sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==
+"@types/node@*", "@types/node@^18.16.3":
+  version "18.16.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.3.tgz#6bda7819aae6ea0b386ebc5b24bdf602f1b42b01"
+  integrity sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -552,15 +552,15 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@typescript-eslint/eslint-plugin@^5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.0.tgz#c0e10eeb936debe5d1c3433cf36206a95befefd0"
-  integrity sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==
+"@typescript-eslint/eslint-plugin@^5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.1.tgz#9b09ee1541bff1d2cebdcb87e7ce4a4003acde08"
+  integrity sha512-AVi0uazY5quFB9hlp2Xv+ogpfpk77xzsgsIEWyVS7uK/c7MZ5tw7ZPbapa0SbfkqE0fsAMkz5UwtgMLVk2BQAg==
   dependencies:
     "@eslint-community/regexpp" "^4.4.0"
-    "@typescript-eslint/scope-manager" "5.59.0"
-    "@typescript-eslint/type-utils" "5.59.0"
-    "@typescript-eslint/utils" "5.59.0"
+    "@typescript-eslint/scope-manager" "5.59.1"
+    "@typescript-eslint/type-utils" "5.59.1"
+    "@typescript-eslint/utils" "5.59.1"
     debug "^4.3.4"
     grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
@@ -568,72 +568,72 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.0.tgz#0ad7cd019346cc5d150363f64869eca10ca9977c"
-  integrity sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==
+"@typescript-eslint/parser@^5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.1.tgz#73c2c12127c5c1182d2e5b71a8fa2a85d215cbb4"
+  integrity sha512-nzjFAN8WEu6yPRDizIFyzAfgK7nybPodMNFGNH0M9tei2gYnYszRDqVA0xlnRjkl7Hkx2vYrEdb6fP2a21cG1g==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.59.0"
-    "@typescript-eslint/types" "5.59.0"
-    "@typescript-eslint/typescript-estree" "5.59.0"
+    "@typescript-eslint/scope-manager" "5.59.1"
+    "@typescript-eslint/types" "5.59.1"
+    "@typescript-eslint/typescript-estree" "5.59.1"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz#86501d7a17885710b6716a23be2e93fc54a4fe8c"
-  integrity sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==
+"@typescript-eslint/scope-manager@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.1.tgz#8a20222719cebc5198618a5d44113705b51fd7fe"
+  integrity sha512-mau0waO5frJctPuAzcxiNWqJR5Z8V0190FTSqRw1Q4Euop6+zTwHAf8YIXNwDOT29tyUDrQ65jSg9aTU/H0omA==
   dependencies:
-    "@typescript-eslint/types" "5.59.0"
-    "@typescript-eslint/visitor-keys" "5.59.0"
+    "@typescript-eslint/types" "5.59.1"
+    "@typescript-eslint/visitor-keys" "5.59.1"
 
-"@typescript-eslint/type-utils@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.0.tgz#8e8d1420fc2265989fa3a0d897bde37f3851e8c9"
-  integrity sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==
+"@typescript-eslint/type-utils@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.1.tgz#63981d61684fd24eda2f9f08c0a47ecb000a2111"
+  integrity sha512-ZMWQ+Oh82jWqWzvM3xU+9y5U7MEMVv6GLioM3R5NJk6uvP47kZ7YvlgSHJ7ERD6bOY7Q4uxWm25c76HKEwIjZw==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.59.0"
-    "@typescript-eslint/utils" "5.59.0"
+    "@typescript-eslint/typescript-estree" "5.59.1"
+    "@typescript-eslint/utils" "5.59.1"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.0.tgz#3fcdac7dbf923ec5251545acdd9f1d42d7c4fe32"
-  integrity sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==
+"@typescript-eslint/types@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.1.tgz#03f3fedd1c044cb336ebc34cc7855f121991f41d"
+  integrity sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==
 
-"@typescript-eslint/typescript-estree@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz#8869156ee1dcfc5a95be3ed0e2809969ea28e965"
-  integrity sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==
+"@typescript-eslint/typescript-estree@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.1.tgz#4aa546d27fd0d477c618f0ca00b483f0ec84c43c"
+  integrity sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==
   dependencies:
-    "@typescript-eslint/types" "5.59.0"
-    "@typescript-eslint/visitor-keys" "5.59.0"
+    "@typescript-eslint/types" "5.59.1"
+    "@typescript-eslint/visitor-keys" "5.59.1"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.0.tgz#063d066b3bc4850c18872649ed0da9ee72d833d5"
-  integrity sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==
+"@typescript-eslint/utils@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.1.tgz#d89fc758ad23d2157cfae53f0b429bdf15db9473"
+  integrity sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.59.0"
-    "@typescript-eslint/types" "5.59.0"
-    "@typescript-eslint/typescript-estree" "5.59.0"
+    "@typescript-eslint/scope-manager" "5.59.1"
+    "@typescript-eslint/types" "5.59.1"
+    "@typescript-eslint/typescript-estree" "5.59.1"
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
-"@typescript-eslint/visitor-keys@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz#a59913f2bf0baeb61b5cfcb6135d3926c3854365"
-  integrity sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==
+"@typescript-eslint/visitor-keys@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.1.tgz#0d96c36efb6560d7fb8eb85de10442c10d8f6058"
+  integrity sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==
   dependencies:
-    "@typescript-eslint/types" "5.59.0"
+    "@typescript-eslint/types" "5.59.1"
     eslint-visitor-keys "^3.3.0"
 
 "@vitest/coverage-c8@^0.30.1":
@@ -1269,7 +1269,7 @@ domelementtype@^2.3.0:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
-domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
+domhandler@^5.0.2, domhandler@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
@@ -1277,13 +1277,13 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
     domelementtype "^2.3.0"
 
 domutils@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
-  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
   dependencies:
     dom-serializer "^2.0.0"
     domelementtype "^2.3.0"
-    domhandler "^5.0.1"
+    domhandler "^5.0.3"
 
 dot-prop@^5.1.0:
   version "5.3.0"
@@ -2340,10 +2340,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-lint-staged@^13.2.1:
-  version "13.2.1"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.2.1.tgz#9d30a14e3e42897ef417bc98556fb757f75cae87"
-  integrity sha512-8gfzinVXoPfga5Dz/ZOn8I2GOhf81Wvs+KwbEXQn/oWZAvCVS2PivrXfVbFJc93zD16uC0neS47RXHIjXKYZQw==
+lint-staged@^13.2.2:
+  version "13.2.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.2.2.tgz#5e711d3139c234f73402177be2f8dd312e6508ca"
+  integrity sha512-71gSwXKy649VrSU09s10uAT0rWCcY3aewhMaHyl2N84oBk4Xs9HgxvUp3AYu+bNsK4NrOYYxvSgg7FyGJ+jGcA==
   dependencies:
     chalk "5.2.0"
     cli-truncate "^3.1.0"
@@ -2357,7 +2357,7 @@ lint-staged@^13.2.1:
     object-inspect "^1.12.3"
     pidtree "^0.6.0"
     string-argv "^0.3.1"
-    yaml "^2.2.1"
+    yaml "^2.2.2"
 
 listr2@^5.0.7:
   version "5.0.8"
@@ -3027,7 +3027,7 @@ pkg-types@^1.0.2:
     mlly "^1.1.1"
     pathe "^1.1.0"
 
-postcss@^8.4.21:
+postcss@^8.4.23:
   version "8.4.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.23.tgz#df0aee9ac7c5e53e1075c24a3613496f9e6552ab"
   integrity sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==
@@ -3217,10 +3217,10 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup@^3.20.2, rollup@^3.20.7:
-  version "3.20.7"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.20.7.tgz#4f045dfb388abe08dd159f8cd286dcaca1e80b28"
-  integrity sha512-P7E2zezKSLhWnTz46XxjSmInrbOCiul1yf+kJccMxT56vxjHwCbDfoLbiqFgu+WQoo9ij2PkraYaBstgB2prBA==
+rollup@^3.21.0, rollup@^3.21.2:
+  version "3.21.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.21.2.tgz#c3a06bc8d235a0c0a8f1f7d9da73426f53706bdc"
+  integrity sha512-c4vC+JZ3bbF4Kqq2TtM7zSKtSyMybFOjqmomFax3xpfYaPZDZ4iz8NMIuBRMjnXOcKYozw7bC6vhJjiWD6JpzQ==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -3232,9 +3232,9 @@ run-parallel@^1.1.9:
     queue-microtask "^1.2.2"
 
 rxjs@^7.8.0:
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
-  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
   dependencies:
     tslib "^2.1.0"
 
@@ -3552,9 +3552,9 @@ time-zone@^1.0.0:
   integrity sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==
 
 tinybench@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.4.0.tgz#83f60d9e5545353610fe7993bd783120bc20c7a7"
-  integrity sha512-iyziEiyFxX4kyxSp+MtY1oCH/lvjH3PxFN8PGCDeqcZWAJ/i+9y+nL85w99PxVzrIvew/GSkSbDYtiGVa85Afg==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.5.0.tgz#4711c99bbf6f3e986f67eb722fed9cddb3a68ba5"
+  integrity sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==
 
 tinypool@^0.4.0:
   version "0.4.0"
@@ -3807,13 +3807,13 @@ vite-node@0.30.1:
     vite "^3.0.0 || ^4.0.0"
 
 "vite@^3.0.0 || ^4.0.0":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.3.1.tgz#9badb1377f995632cdcf05f32103414db6fbb95a"
-  integrity sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.3.3.tgz#26adb4aa01439fc4546c480ea547674d87289396"
+  integrity sha512-MwFlLBO4udZXd+VBcezo3u8mC77YQk+ik+fbc0GZWGgzfbPP+8Kf0fldhARqvSYmtIWoAJ5BXPClUbMTlqFxrA==
   dependencies:
     esbuild "^0.17.5"
-    postcss "^8.4.21"
-    rollup "^3.20.2"
+    postcss "^8.4.23"
+    rollup "^3.21.0"
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -3930,10 +3930,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.1.tgz#3014bf0482dcd15147aa8e56109ce8632cd60ce4"
-  integrity sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==
+yaml@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
+  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.9:
   version "20.2.9"
@@ -3959,9 +3959,9 @@ yargs@^16.2.0:
     yargs-parser "^20.2.2"
 
 yargs@^17.0.0:
-  version "17.7.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
-  integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (feba58da887bfe1158540655a377213ad56ffa10)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/doctoc/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/doctoc/doctoc/package.json

 @technote-space/anchor-markdown-header   ^1.1.39  →   ^1.1.40
 @types/node                             ^18.16.0  →  ^18.16.3
 @typescript-eslint/eslint-plugin         ^5.59.0  →   ^5.59.1
 @typescript-eslint/parser                ^5.59.0  →   ^5.59.1
 lint-staged                              ^13.2.1  →   ^13.2.2
 rollup                                   ^3.20.7  →   ^3.21.2

Run yarn install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 17.43s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 371 new dependencies.
info Direct dependencies
├─ @commitlint/cli@17.6.1
├─ @commitlint/config-conventional@17.6.1
├─ @rollup/plugin-typescript@11.1.0
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/anchor-markdown-header@1.1.40
├─ @textlint/markdown-to-ast@13.3.2
├─ @typescript-eslint/eslint-plugin@5.59.1
├─ @typescript-eslint/parser@5.59.1
├─ @vitest/coverage-c8@0.30.1
├─ eslint-plugin-import@2.27.5
├─ eslint@8.39.0
├─ htmlparser2@8.0.2
├─ husky@8.0.3
├─ lint-staged@13.2.2
├─ rollup@3.21.2
├─ typescript@5.0.4
├─ update-section@0.3.3
└─ vitest@0.30.1
info All dependencies
├─ @babel/code-frame@7.21.4
├─ @babel/helper-validator-identifier@7.19.1
├─ @babel/highlight@7.18.6
├─ @bcoe/v8-coverage@0.2.3
├─ @commitlint/cli@17.6.1
├─ @commitlint/config-conventional@17.6.1
├─ @commitlint/ensure@17.4.4
├─ @commitlint/execute-rule@17.4.0
├─ @commitlint/format@17.4.4
├─ @commitlint/is-ignored@17.4.4
├─ @commitlint/lint@17.6.1
├─ @commitlint/load@17.5.0
├─ @commitlint/message@17.4.2
├─ @commitlint/parse@17.4.4
├─ @commitlint/read@17.5.1
├─ @commitlint/resolve-extends@17.4.4
├─ @commitlint/rules@17.6.1
├─ @commitlint/to-lines@17.4.0
├─ @commitlint/top-level@17.4.0
├─ @cspotcode/source-map-support@0.8.1
├─ @esbuild/linux-x64@0.17.18
├─ @eslint/eslintrc@2.0.2
├─ @eslint/js@8.39.0
├─ @humanwhocodes/config-array@0.11.8
├─ @humanwhocodes/module-importer@1.0.1
├─ @humanwhocodes/object-schema@1.2.1
├─ @istanbuljs/schema@0.1.3
├─ @jridgewell/resolve-uri@3.1.0
├─ @jridgewell/sourcemap-codec@1.4.15
├─ @jridgewell/trace-mapping@0.3.18
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.8
├─ @rollup/plugin-typescript@11.1.0
├─ @rollup/pluginutils@5.0.2
├─ @sindresorhus/tsconfig@3.0.1
├─ @technote-space/anchor-markdown-header@1.1.40
├─ @textlint/markdown-to-ast@13.3.2
├─ @tsconfig/node10@1.0.9
├─ @tsconfig/node12@1.0.11
├─ @tsconfig/node14@1.0.3
├─ @tsconfig/node16@1.0.3
├─ @types/chai-subset@1.3.3
├─ @types/chai@4.3.5
├─ @types/estree@1.0.1
├─ @types/istanbul-lib-coverage@2.0.4
├─ @types/json-schema@7.0.11
├─ @types/json5@0.0.29
├─ @types/mdast@3.0.11
├─ @types/minimist@1.2.2
├─ @types/normalize-package-data@2.4.1
├─ @types/semver@7.3.13
├─ @typescript-eslint/eslint-plugin@5.59.1
├─ @typescript-eslint/parser@5.59.1
├─ @typescript-eslint/type-utils@5.59.1
├─ @vitest/coverage-c8@0.30.1
├─ @vitest/expect@0.30.1
├─ @vitest/runner@0.30.1
├─ @vitest/snapshot@0.30.1
├─ acorn-jsx@5.3.2
├─ acorn-walk@8.2.0
├─ aggregate-error@3.1.0
├─ ajv@6.12.6
├─ ansi-escapes@4.3.2
├─ arg@4.1.3
├─ argparse@2.0.1
├─ array-buffer-byte-length@1.0.0
├─ array-ify@1.0.0
├─ array-includes@3.1.6
├─ array-union@2.1.0
├─ array.prototype.flat@1.3.1
├─ array.prototype.flatmap@1.3.1
├─ arrify@1.0.1
├─ assertion-error@1.1.0
├─ bail@1.0.5
├─ balanced-match@1.0.2
├─ blueimp-md5@2.19.0
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ c8@7.13.0
├─ callsites@3.1.0
├─ camelcase-keys@6.2.2
├─ camelcase@5.3.1
├─ ccount@1.1.0
├─ chalk@4.1.2
├─ character-entities-legacy@1.1.4
├─ character-entities@1.2.4
├─ character-reference-invalid@1.1.4
├─ check-error@1.0.2
├─ clean-stack@2.2.0
├─ cli-cursor@3.1.0
├─ cli-truncate@3.1.0
├─ cliui@8.0.1
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ colorette@2.0.20
├─ commander@10.0.1
├─ concat-map@0.0.1
├─ conventional-changelog-angular@5.0.13
├─ conventional-changelog-conventionalcommits@5.0.0
├─ conventional-commits-parser@3.2.4
├─ convert-source-map@1.9.0
├─ cosmiconfig-typescript-loader@4.3.0
├─ cosmiconfig@8.1.3
├─ create-require@1.1.1
├─ dargs@7.0.0
├─ date-time@3.1.0
├─ decamelize-keys@1.1.1
├─ decamelize@1.2.0
├─ deep-eql@4.1.3
├─ deep-is@0.1.4
├─ diff@4.0.2
├─ dir-glob@3.0.1
├─ doctrine@2.1.0
├─ dom-serializer@2.0.0
├─ domhandler@5.0.3
├─ domutils@3.1.0
├─ dot-prop@5.3.0
├─ eastasianwidth@0.2.0
├─ emoji-regex@10.2.1
├─ entities@4.5.0
├─ error-ex@1.3.2
├─ es-set-tostringtag@2.0.1
├─ es-to-primitive@1.2.1
├─ esbuild@0.17.18
├─ eslint-import-resolver-node@0.3.7
├─ eslint-module-utils@2.8.0
├─ eslint-plugin-import@2.27.5
├─ eslint-scope@7.2.0
├─ eslint@8.39.0
├─ esquery@1.5.0
├─ estraverse@5.3.0
├─ estree-walker@2.0.2
├─ esutils@2.0.3
├─ extend@3.0.2
├─ fast-diff@1.2.0
├─ fast-glob@3.2.12
├─ fast-json-stable-stringify@2.1.0
├─ fast-levenshtein@2.0.6
├─ fastq@1.15.0
├─ fault@1.0.4
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ flat-cache@3.0.4
├─ flatted@3.2.7
├─ foreground-child@2.0.0
├─ format@0.2.2
├─ fs-extra@11.1.1
├─ fs.realpath@1.0.0
├─ function.prototype.name@1.1.5
├─ functions-have-names@1.2.3
├─ get-stream@6.0.1
├─ get-symbol-description@1.0.0
├─ git-raw-commits@2.0.11
├─ glob-parent@6.0.2
├─ glob@7.2.3
├─ global-dirs@0.1.1
├─ globalthis@1.0.3
├─ globby@11.1.0
├─ graceful-fs@4.2.11
├─ hard-rejection@2.1.0
├─ has-bigints@1.0.2
├─ has-flag@4.0.0
├─ has-proto@1.0.1
├─ hosted-git-info@4.1.0
├─ html-escaper@2.0.2
├─ htmlparser2@8.0.2
├─ human-signals@2.1.0
├─ husky@8.0.3
├─ imurmurhash@0.1.4
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ini@1.3.8
├─ internal-slot@1.0.5
├─ is-alphabetical@1.0.4
├─ is-alphanumerical@1.0.4
├─ is-array-buffer@3.0.2
├─ is-arrayish@0.2.1
├─ is-bigint@1.0.4
├─ is-boolean-object@1.1.2
├─ is-callable@1.2.7
├─ is-date-object@1.0.5
├─ is-extglob@2.1.1
├─ is-hexadecimal@1.0.4
├─ is-negative-zero@2.0.2
├─ is-number-object@1.0.7
├─ is-number@7.0.0
├─ is-obj@2.0.0
├─ is-path-inside@3.0.3
├─ is-plain-obj@2.1.0
├─ is-shared-array-buffer@1.0.2
├─ is-stream@2.0.1
├─ is-string@1.0.7
├─ is-symbol@1.0.4
├─ is-text-path@1.0.1
├─ is-weakref@1.0.2
├─ isexe@2.0.0
├─ istanbul-lib-coverage@3.2.0
├─ istanbul-reports@3.1.5
├─ js-sdsl@4.4.0
├─ js-string-escape@1.0.1
├─ js-tokens@4.0.0
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json5@1.0.2
├─ jsonc-parser@3.2.0
├─ jsonfile@6.1.0
├─ jsonparse@1.3.1
├─ JSONStream@1.3.5
├─ kind-of@6.0.3
├─ lilconfig@2.1.0
├─ lines-and-columns@1.2.4
├─ lint-staged@13.2.2
├─ listr2@5.0.8
├─ local-pkg@0.4.3
├─ locate-path@6.0.0
├─ lodash.camelcase@4.3.0
├─ lodash.isfunction@3.0.9
├─ lodash.isplainobject@4.0.6
├─ lodash.kebabcase@4.1.1
├─ lodash.mergewith@4.6.2
├─ lodash.snakecase@4.1.1
├─ lodash.startcase@4.4.0
├─ lodash.uniq@4.5.0
├─ lodash.upperfirst@4.3.1
├─ log-update@4.0.0
├─ longest-streak@2.0.4
├─ loupe@2.3.6
├─ make-dir@3.1.0
├─ make-error@1.3.6
├─ map-obj@1.0.1
├─ markdown-table@2.0.0
├─ md5-hex@3.0.1
├─ mdast-util-find-and-replace@1.1.1
├─ mdast-util-footnote@0.1.7
├─ mdast-util-from-markdown@0.8.5
├─ mdast-util-frontmatter@0.2.0
├─ mdast-util-gfm-autolink-literal@0.1.3
├─ mdast-util-gfm-strikethrough@0.2.3
├─ mdast-util-gfm-table@0.1.6
├─ mdast-util-gfm-task-list-item@0.1.6
├─ mdast-util-gfm@0.1.2
├─ merge2@1.4.1
├─ micromark-extension-footnote@0.3.2
├─ micromark-extension-gfm-autolink-literal@0.5.7
├─ micromark-extension-gfm-strikethrough@0.6.5
├─ micromark-extension-gfm-table@0.4.3
├─ micromark-extension-gfm-tagfilter@0.3.0
├─ micromark-extension-gfm-task-list-item@0.3.3
├─ micromark-extension-gfm@0.3.3
├─ micromatch@4.0.5
├─ mimic-fn@2.1.0
├─ min-indent@1.0.1
├─ minimist-options@4.1.0
├─ minimist@1.2.8
├─ mlly@1.2.0
├─ ms@2.1.2
├─ nanoid@3.3.6
├─ natural-compare-lite@1.4.0
├─ natural-compare@1.4.0
├─ normalize-package-data@3.0.3
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ object.assign@4.1.4
├─ object.values@1.1.6
├─ onetime@5.1.2
├─ optionator@0.9.1
├─ p-limit@4.0.0
├─ p-locate@5.0.0
├─ p-map@4.0.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ pathval@1.1.1
├─ pidtree@0.6.0
├─ pkg-types@1.0.2
├─ postcss@8.4.23
├─ punycode@2.3.0
├─ queue-microtask@1.2.3
├─ quick-lru@4.0.1
├─ react-is@17.0.2
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ readable-stream@3.6.2
├─ redent@3.0.0
├─ regexp.prototype.flags@1.5.0
├─ remark-footnotes@3.0.0
├─ remark-frontmatter@3.0.0
├─ remark-gfm@1.0.0
├─ remark-parse@9.0.0
├─ require-from-string@2.0.2
├─ resolve-global@1.0.0
├─ restore-cursor@3.1.0
├─ reusify@1.0.4
├─ rfdc@1.3.0
├─ rollup@3.21.2
├─ run-parallel@1.2.0
├─ rxjs@7.8.1
├─ safe-buffer@5.2.1
├─ safe-regex-test@1.0.0
├─ semver@7.5.0
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ side-channel@1.0.4
├─ siginfo@2.0.0
├─ slash@3.0.0
├─ slice-ansi@5.0.0
├─ source-map-js@1.0.2
├─ source-map@0.6.1
├─ spdx-correct@3.2.0
├─ spdx-exceptions@2.3.0
├─ stackback@0.0.2
├─ string_decoder@1.3.0
├─ string-argv@0.3.1
├─ string.prototype.trim@1.2.7
├─ string.prototype.trimend@1.0.6
├─ string.prototype.trimstart@1.0.6
├─ strip-bom@3.0.0
├─ strip-final-newline@2.0.0
├─ strip-indent@3.0.0
├─ strip-json-comments@3.1.1
├─ strip-literal@1.0.1
├─ supports-preserve-symlinks-flag@1.0.0
├─ test-exclude@6.0.0
├─ text-extensions@1.9.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ time-zone@1.0.0
├─ tinybench@2.5.0
├─ tinypool@0.4.0
├─ tinyspy@2.1.0
├─ to-regex-range@5.0.1
├─ traverse@0.6.7
├─ trim-newlines@3.0.1
├─ trough@1.0.5
├─ ts-node@10.9.1
├─ tsconfig-paths@3.14.2
├─ tslib@1.14.1
├─ type-check@0.4.0
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typed-array-length@1.0.4
├─ typescript@5.0.4
├─ ufo@1.1.1
├─ unbox-primitive@1.0.2
├─ unified@9.2.2
├─ unist-util-visit-parents@3.1.1
├─ update-section@0.3.3
├─ util-deprecate@1.0.2
├─ v8-compile-cache-lib@3.0.1
├─ v8-to-istanbul@9.1.0
├─ vfile-message@2.0.4
├─ vfile@4.2.1
├─ vite-node@0.30.1
├─ vitest@0.30.1
├─ well-known-symbols@2.0.0
├─ which-boxed-primitive@1.0.2
├─ which-typed-array@1.1.9
├─ which@2.0.2
├─ why-is-node-running@2.2.2
├─ word-wrap@1.2.3
├─ yallist@4.0.0
├─ yaml@2.2.2
├─ yargs-parser@20.2.9
├─ yargs@17.7.2
├─ yn@3.1.1
├─ yocto-queue@1.0.0
└─ zwitch@1.0.5
Done in 10.65s.
```



</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.19
0 vulnerabilities found - Packages audited: 572
Done in 0.65s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)